### PR TITLE
Fixed the AMQP generator + 'rake spec'

### DIFF
--- a/lib/daemon_kit.rb
+++ b/lib/daemon_kit.rb
@@ -13,7 +13,7 @@ $LOAD_PATH.unshift( File.dirname(__FILE__).to_absolute_path ) unless
   $LOAD_PATH.include?( File.dirname(__FILE__).to_absolute_path )
 
 module DaemonKit
-  VERSION = '0.1.8.1'
+  VERSION = '0.1.8.2'
 
   autoload :Initializer,    'daemon_kit/initializer'
   autoload :Application,    'daemon_kit/application'

--- a/lib/daemon_kit/dk_amqp.rb
+++ b/lib/daemon_kit/dk_amqp.rb
@@ -1,5 +1,5 @@
 require 'yaml'
-require 'mq'
+require 'amqp'
 
 module DaemonKit
   # Thin wrapper around the amqp gem, specifically designed to ease

--- a/lib/generators/daemon_kit/amqp/templates/config/pre-daemonize/amqp.rb
+++ b/lib/generators/daemon_kit/amqp/templates/config/pre-daemonize/amqp.rb
@@ -1,6 +1,5 @@
 begin
   require 'amqp'
-  require 'mq'
 rescue LoadError
   $stderr.puts "Missing amqp gem. Please run 'bundle install'."
   exit 1

--- a/lib/generators/daemon_kit/amqp/templates/libexec/%app_name%-daemon.rb
+++ b/lib/generators/daemon_kit/amqp/templates/libexec/%app_name%-daemon.rb
@@ -30,7 +30,7 @@ DaemonKit::AMQP.run do
   #   end
   # end
 
-  amq = ::MQ.new
+  amq = AMQP::Channel.new
   amq.queue('test').subscribe do |msg|
     DaemonKit.logger.debug "Received message: #{msg.inspect}"
   end

--- a/spec/error_handlers_spec.rb
+++ b/spec/error_handlers_spec.rb
@@ -3,7 +3,7 @@ require File.dirname(__FILE__) + '/spec_helper'
 describe DaemonKit::Safety do
 end
 
-describe DaemonKit::ErrorHandlers::Mail do
+describe "DaemonKit::ErrorHandlers::Mail" do
   it "should send an email report" do
     conf = Object.new
     conf.stubs(:daemon_name).returns('test')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 require 'rubygems'
-gem 'rspec'
-require 'spec'
+require 'rspec'
 
 require 'mocha'
 require 'fileutils'
@@ -11,7 +10,7 @@ DAEMON_ROOT = "#{File.dirname(__FILE__)}/../tmp"
 $:.unshift( File.dirname(__FILE__) + '/../lib' )
 require 'daemon_kit'
 
-Spec::Runner.configure do |config|
+RSpec.configure do |config|
   # == Mock Framework
   #
   # RSpec uses it's own mocking framework by default. If you prefer to

--- a/tasks/rspec.rake
+++ b/tasks/rspec.rake
@@ -1,16 +1,15 @@
 begin
-  require 'spec'
+  require 'rspec'
 rescue LoadError
   require 'rubygems'
-  require 'spec'
+  require 'rspec'
 end
 begin
-  require 'spec/rake/spectask'
+  require 'rspec/core/rake_task'
 
   desc "Run the specs under spec/models"
-  Spec::Rake::SpecTask.new do |t|
-    t.spec_opts = ['--options', "spec/spec.opts"]
-    t.spec_files = FileList['spec/**/*_spec.rb']
+  RSpec::Core::RakeTask.new do |t|
+    t.rspec_opts = ['--options', "spec/spec.opts"]
   end
 rescue LoadError
   puts <<-EOS


### PR DESCRIPTION
The AMQP gem is getting some love recently. Part of this love is the deprecation of `require "mq"` and the generally everything that lived in `mq.rb`. This commit fixes the generator to spit out a working skeleton.

I also slapped RSpec into submission (the RSpec-2 upgrade stuff) just to check I didn't break anything.
