### PR TITLE
Update post-install instructions

### DIFF
--- a/PostInstall.txt
+++ b/PostInstall.txt
@@ -1,7 +1,0 @@
-
-For more information on daemon-kit, see http://kit.rubyforge.org/daemon-kit
-
-For usage options, run:
-
-$ daemon-kit -h
-

--- a/daemon-kit.gemspec
+++ b/daemon-kit.gemspec
@@ -10,7 +10,9 @@ Gem::Specification.new do |gem|
   gem.post_install_message = %q{
 For more information on daemon-kit, see http://kit.rubyforge.org/daemon-kit
 
-To get started quickly run 'daemon-kit' without any arguments
+For usage options, run:
+
+$ daemon-kit -h
 
 
 }
@@ -27,7 +29,6 @@ To get started quickly run 'daemon-kit' without any arguments
                           "Deployment.txt",
                           "History.txt",
                           "Logging.txt",
-                          "PostInstall.txt",
                           "README.rdoc",
                           "RuoteParticipants.txt",
                           "TODO.txt",


### PR DESCRIPTION
The old instructions appeared to be out of date. Replaced it with a message about how to get the help output.
