### PR TITLE
Clarify comment in environment

### DIFF
--- a/lib/generators/daemon_kit/app/templates/config/environment.rb.tt
+++ b/lib/generators/daemon_kit/app/templates/config/environment.rb.tt
@@ -6,7 +6,7 @@
 # Boot up
 require File.join(File.dirname(__FILE__), 'boot')
 
-# Auto-require default libraries and those for the current Rails environment.
+# Auto-require default libraries and those for the current ruby environment.
 Bundler.require :default, DaemonKit.env
 
 DaemonKit::Initializer.run do |config|


### PR DESCRIPTION
Replacing reference to `rails` with `ruby`, since daemons
are likely to have nothing to do with rails.
