### PR TITLE
remove dup's in #update_gemfile for rspec generator

### DIFF
--- a/lib/generators/daemon_kit/rspec/rspec_generator.rb
+++ b/lib/generators/daemon_kit/rspec/rspec_generator.rb
@@ -3,13 +3,9 @@ module DaemonKit
     class SpecGenerator < Base
 
       def update_gemfile
-        append_file 'Gemfile', "group :development, :test do\n  gem 'rspec'\nend\n"
-        append_file 'Gemfile', <<-GEM
-group :development, :test do
-  gem 'rake'
-  gem 'rspec'
-end
-GEM
+        append_file 'Gemfile' do
+          %Q{group :development, :test do\n  gem 'rake'\n  gem 'rspec' \nend}
+        end
       end
 
       def create_specs


### PR DESCRIPTION
In `DaemonKit::Generators::SpecGenerator#update_gemfile` there is multiple entries for `group develoment, test` and `rspec`

``` ruby
      def update_gemfile
        append_file 'Gemfile', "group :development, :test do\n  gem 'rspec'\nend\n"
        append_file 'Gemfile', <<-GEM
group :development, :test do
  gem 'rake'
  gem 'rspec'
end
GEM
      end
```

This produces duplication in `Gemfile` upon newly created daemon

``` ruby
 group :development, :test do
    gem 'rspec'
 end
 group :development, :test do
    gem 'rake'
    gem 'rspec'
 end
```

Take care,
Brad
