### PR TITLE
Add host and port to blather setup

### DIFF
--- a/lib/daemon_kit/xmpp.rb
+++ b/lib/daemon_kit/xmpp.rb
@@ -34,7 +34,9 @@ module DaemonKit
         @config.jabber_id
       end
 
-      setup jid, @config.password
+      # host & port allow nil, defaults to the jabber id host and default port
+      # so if those keys are not present in the config, its ok.
+      setup jid, @config.password, @config.host, @config.port
 
       when_ready do
         configure_roster!


### PR DESCRIPTION
Allows custom xmpp host and port in the xmpp yaml config.
