### PR TITLE
Removed dependency on I18n.

### DIFF
--- a/daemon-kit.gemspec
+++ b/daemon-kit.gemspec
@@ -46,5 +46,4 @@ $ daemon-kit -h
 
   gem.add_dependency(%q<thor>)
   gem.add_runtime_dependency(%q<eventmachine>, [">= 0.12.10"])
-  gem.add_runtime_dependency(%q<i18n>)
 end


### PR DESCRIPTION
This Gem is not used anywhere and by loading it as a runtime dependency we end
up with a larger dependency graph than needed.
