### PR TITLE
Cron daemon uses 2.x version of rufus-scheduler

### DIFF
--- a/lib/generators/daemon_kit/cron/cron_generator.rb
+++ b/lib/generators/daemon_kit/cron/cron_generator.rb
@@ -3,7 +3,7 @@ module DaemonKit
     class CronGenerator < Base
 
       def update_gemfile
-        append_file 'Gemfile', "\ngem 'rufus-scheduler', '>= 2.0.3'\n"
+        append_file 'Gemfile', "\ngem 'rufus-scheduler', '~> 2.0'\n"
       end
 
       def create_initializers


### PR DESCRIPTION
With the >= 2.0.3 version lock bundler will install a 3.x version of
rufus-scheduler. Using this version of rufus gives me errors. So I'm
locking the gem to a 2.x version of rufus-scheduler.
