### PR TITLE
Require fcntl

### DIFF
--- a/lib/daemon_kit/application.rb
+++ b/lib/daemon_kit/application.rb
@@ -1,3 +1,4 @@
+require 'fcntl'
 require 'timeout'
 
 module DaemonKit


### PR DESCRIPTION
I have a daemon that is crashing because I'm cleaning log files that were opened and then the process is trying to write to them, and I'm getting the error `NameError: uninitialized constant #<Class:DaemonKit::Application>::Fcntl`. 

I've tried it in many versions of Ruby as far back as `1.9.3` and it seems like the constant `Fcntl` is not part of Ruby core and you have to actually require it.